### PR TITLE
Wait for font load

### DIFF
--- a/src/pages/api/_lib/chromium.ts
+++ b/src/pages/api/_lib/chromium.ts
@@ -24,6 +24,7 @@ export async function getScreenshot(
 
   await page.setViewport({ width: 1200, height: 630 })
   await page.setContent(html)
+  await page.evaluateHandle('document.fonts.ready');
 
   const file = await page.screenshot({ type: 'png' })
 


### PR DESCRIPTION
Puppeteer was taking screenshot before the robot font loaded.
The first request after server start always had the default font.